### PR TITLE
Format ruby with standard or rubocop as appropriate

### DIFF
--- a/config/nvim/lua/plugins/formatting.lua
+++ b/config/nvim/lua/plugins/formatting.lua
@@ -9,6 +9,32 @@ return {
 			typescript = { "prettierd", "prettier", stop_after_first = true },
 			yaml = { "prettierd", "prettier", stop_after_first = true },
 			lua = { "stylua" },
+			ruby = function()
+				local function has_standard()
+					local standard_yml = io.open("standard.yml")
+					if standard_yml then
+						standard_yml:close()
+						return true
+					end
+
+					local gemfile = io.open("Gemfile")
+					if gemfile then
+						local content = gemfile:read("*all")
+						gemfile:close()
+						if content:match('gem "standard"') or content:match("gem 'standard'") then
+							return true
+						end
+					end
+
+					return false
+				end
+
+				if has_standard() then
+					return { "standardrb" }
+				else
+					return { "rubocop" }
+				end
+			end,
 		},
 		format_on_save = {
 			lsp_fallback = true,


### PR DESCRIPTION
Add support for Ruby formatting in Neovim configuration.

* Add `ruby` to the `formatters_by_ft` table with a custom function to check for the presence of `standard.yml` or `Gemfile` containing `gem "standard"` to determine the formatter.
* Use `standardrb` as the formatter if `standard.yml` or `gem "standard"` is found, otherwise use `rubocop`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/derekprior/dotfiles/pull/26?shareId=2c935fd7-18c8-45ad-a545-e7467e360fb0).